### PR TITLE
fix(dnsdist): disable security status polling via DNS

### DIFF
--- a/containers/dnsdist/config/dnsdist.conf
+++ b/containers/dnsdist/config/dnsdist.conf
@@ -1,5 +1,7 @@
 -- udp/tcp dns listening
 setLocal("0.0.0.0:53", {})
+-- disable security status polling via DNS
+setSecurityPollSuffix("")
 
 -- Local Bind
 newServer({


### PR DESCRIPTION
```
Mar 13 11:32:15 Error while retrieving the security update for version dnsdist-1.8.2: Unable to get a valid Security Status update
Mar 13 11:32:15 Failed to retrieve security status update for '1.8.2' on dnsdist-1.8.2.security-status.secpoll.powerdns.com.
```

Get outta here!

Ref: https://phabricator.wikimedia.org/T273322